### PR TITLE
Allow creating TTL'd sessions without a node

### DIFF
--- a/agent/consul/session_endpoint.go
+++ b/agent/consul/session_endpoint.go
@@ -57,8 +57,8 @@ func (s *Session) Apply(args *structs.SessionRequest, reply *string) error {
 	if args.Session.ID == "" && args.Op == structs.SessionDestroy {
 		return fmt.Errorf("Must provide ID")
 	}
-	if args.Session.Node == "" && args.Op == structs.SessionCreate {
-		return fmt.Errorf("Must provide Node")
+	if args.Session.Node == "" && len(args.Session.NodeChecks) > 0 && args.Op == structs.SessionCreate {
+		return fmt.Errorf("Must provide Node when NodeChecks are specified")
 	}
 
 	//  The entMeta to populate is the one in the Session struct, not SessionRequest

--- a/agent/consul/state/session_test.go
+++ b/agent/consul/state/session_test.go
@@ -53,7 +53,11 @@ func TestStateStore_SessionCreate_SessionGet(t *testing.T) {
 	}
 
 	// Registering with an unknown node is disallowed
-	sess = &structs.Session{ID: testUUID()}
+	sess = &structs.Session{
+		ID:         testUUID(),
+		Node:       "nonextant-node",
+		NodeChecks: []string{string(structs.SerfCheckID)},
+	}
 	if err := s.SessionCreate(1, sess); err != ErrMissingNode {
 		t.Fatalf("expected %#v, got: %#v", ErrMissingNode, err)
 	}


### PR DESCRIPTION
This is required to be able to hold cross-DC locks.

### Description

<!-- Please describe why you're making this change, in plain English. -->

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
